### PR TITLE
Update and build with OpenSSL 3 [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+aggregate_branch: openssl3_builds
+
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-aggregate_branch: openssl3_builds
-
-build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nginx" %}
-{% set version = "1.21.6" %}
+{% set version = "1.25.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,19 +8,17 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://nginx.org/download/{{ name }}-{{ version }}.tar.gz
-  sha256: 66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae
+  sha256: 5ed44d45943272a4e8a5bcf4434237210f2de31b903fca5e381c1bbd7eee1e8c
   patches:
     - pcre-config.patch  # find pcre in PREFIX instead of /usr
 
 build:
-  number: 1
+  number: 0
   no_link:
     - etc/*
     - var/log/nginx/*
   # nginx and libgd currently isn't available on s390x 
   skip: true  # [win or s390x]
-  ignore_run_exports:
-    - libgfortran5  # [osx and arm64]
 
 requirements:
   build:
@@ -33,14 +31,14 @@ requirements:
   host:
     - libgd {{ libgd }}
     - libxslt 1.1.*
-    - openssl
-    - pcre2
-    - zlib
+    - openssl {{ openssl }}
+    - pcre2 10.42
+    - zlib {{ zlib }}
   run:
     - libgd {{ libgd }}
     - libxml2
     - libxslt 1.1.*
-    - openssl
+    - openssl 3.*
     - pcre2
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,13 +42,11 @@ requirements:
     - pcre2
 
 test:
-  commands:
-    - nginx -h
   requires:
     - curl
 
 about:
-  home: https://www.nginx.org
+  home: https://nginx.org
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+set -e
 set +x
+
+nginx -h
 
 if [[ "${target_platform}" == linux-aarch64 ]]; then
    # Skip testing on aarch64 because 'ps' is not found


### PR DESCRIPTION
OpenSSL 3 support was added in 1.22.0 (see http://nginx.org/2022.html). So updating to the latest version since we need to update anyway.

I also removed the `ignore_run_exports` since it didn't make sense and didn't have any effect anyway since `libgfortran5` is not a direct host dependency.