### PR TITLE
Force a rebuild. The previous PR did not trigger a build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - libgd {{ libgd }}
     - libxslt 1.1.*
-    - openssl {{ openssl }}
+    - openssl 3.0.8
     - pcre2 10.42
     - zlib {{ zlib }}
   run:


### PR DESCRIPTION
https://github.com/AnacondaRecipes/nginx-feedstock/pull/10 was merged with "skip ci".