### PR TITLE
nginx 1.26.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ build:
   no_link:
     - etc/*
     - var/log/nginx/*
-  # nginx and libgd currently isn't available on s390x 
-  skip: true  # [win or s390x]
+  skip: true  # [win]
 
 requirements:
   build:
@@ -27,7 +26,7 @@ requirements:
     - {{ compiler('fortran') }}  # [not osx]
     - make
     - m2-patch  # [win]
-    - patch  # [not win] 
+    - patch  # [not win]
   host:
     - libgd {{ libgd }}
     - libxslt 1.1.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nginx" %}
-{% set version = "1.25.0" %}
+{% set version = "1.26.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://nginx.org/download/{{ name }}-{{ version }}.tar.gz
-  sha256: 5ed44d45943272a4e8a5bcf4434237210f2de31b903fca5e381c1bbd7eee1e8c
+  sha256: 69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
   patches:
     - pcre-config.patch  # find pcre in PREFIX instead of /usr
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   host:
     - libgd {{ libgd }}
     - libxslt 1.1.*
+    - libxml2 {{ libxml2 }}
     - openssl 3.0.8
     - pcre2 10.42
     - zlib {{ zlib }}


### PR DESCRIPTION
[PKG-7971](https://anaconda.atlassian.net/browse/PKG-7971)
[upstream](https://hg.nginx.org/nginx)

- Updated to newest version
- Recipe cleanup

[PKG-7971]: https://anaconda.atlassian.net/browse/PKG-7971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ