### PR TITLE
v1.29.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nginx" %}
-{% set version = "1.29.5" %}
+{% set version = "1.29.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://nginx.org/download/{{ name }}-{{ version }}.tar.gz
-  sha256: 6744768a4114880f37b13a0443244e731bcb3130c0a065d7e37d8fd589ade374
+  sha256: 673f8fb8c0961c44fbd9410d6161831453609b44063d3f2948253fc2b5692139
   patches:
     - pcre-config.patch  # find pcre in PREFIX instead of /usr
 


### PR DESCRIPTION
nginx v1.29.7

**Destination channel:**  defaults

### Links

- [PKG-13259](https://anaconda.atlassian.net/browse/PKG-13259) 
- [Upstream repository](https://github.com/nginx/nginx/tree/release-1.29.7)
- [Upstream changelog/diff](https://github.com/nginx/nginx/releases/tag/release-1.29.7)


### Explanation of changes:

- Bump version and SHA

### Notes
- This release addresses several CVEs

[PKG-13259]: https://anaconda.atlassian.net/browse/PKG-13259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ