### PR TITLE
Update version to 1.30.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nginx" %}
-{% set version = "1.30.0" %}
+{% set version = "1.30.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://nginx.org/download/{{ name }}-{{ version }}.tar.gz
-  sha256: 058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b
+  sha256: 99765000d974896b31ca5882d8c279ce3fe7ef6f5c6f9f0a967ed7fd3407f9cc
   patches:
     - pcre-config.patch  # find pcre in PREFIX instead of /usr
 


### PR DESCRIPTION
nginx 1.30.1

**Destination channel:**  defaults

### Links

- [PKG-14791](https://anaconda.atlassian.net/browse/PKG-14791) 
- [Upstream repository](https://github.com/nginx/nginx/tree/release-1.30.1

### Explanation of changes:
- New version number



[PKG-14791]: https://anaconda.atlassian.net/browse/PKG-14791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ