### PR TITLE
Update version to 1.30.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nginx" %}
-{% set version = "1.30.1" %}
+{% set version = "1.30.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://nginx.org/download/{{ name }}-{{ version }}.tar.gz
-  sha256: 99765000d974896b31ca5882d8c279ce3fe7ef6f5c6f9f0a967ed7fd3407f9cc
+  sha256: e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f
   patches:
     - pcre-config.patch  # find pcre in PREFIX instead of /usr
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - libgd
     - libxml2
     - libxslt
+    - libzlib
     - openssl
     - pcre2
 


### PR DESCRIPTION
nginx 1.30.3

**Destination channel:**  defaults

### Links

- [PKG-15625](https://anaconda.atlassian.net/browse/PKG-15625) 
- [Upstream repository](https://github.com/nginx/nginx/tree/release-1.30.3)

### Explanation of changes:
- New version number

[PKG-15625]: https://anaconda.atlassian.net/browse/PKG-15625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ